### PR TITLE
feat: new registryUrl option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.0
+
+- Added new `registryUrl` option
+
 # 5.0.1
 
 - Fixed a bug where getting the latest version might crash when an invalid npmrc file was found

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ getLatestVersion('some-module', {auth: false})
   .catch((err) => console.error(err))
 ```
 
+## Using custom registry
+
+By default, module utilizes [registry-url](https://www.npmjs.com/package/registry-url) to resolve registry URL from NPM configuration files. However, if you need to set up the registry programmatically, you can make use of the `registryUrl` option:
+
+```js
+getLatestVersion('some-module', {registryUrl: 'https://some-custom-registry.com'})
+  .then((version) => console.log(version))
+  .catch((err) => console.error(err))
+```
+
+
 ## Developing
 
 ```bash

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@ declare namespace getLatestVersion {
   interface BaseOptions {
     readonly auth?: boolean
     readonly range?: string
+    readonly registryUrl?: string
   }
   interface WithLatestOptions extends BaseOptions {
     readonly includeLatest: true

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,14 @@ function shouldRetry(err, num, options) {
   )
 }
 
+function resolveRegistryUrl(pkgName, options) {
+  if (options.registryUrl) {
+    return options.registryUrl
+  }
+  const scope = pkgName.split('/')[0]
+  return registryUrl(scope);
+}
+
 const httpRequest = getIt([
   jsonResponse({force: true}),
   httpErrors(),
@@ -29,14 +37,13 @@ const httpRequest = getIt([
 ])
 
 async function getLatestVersion(pkgName, opts) {
-  const scope = pkgName.split('/')[0]
-  const regUrl = registryUrl(scope)
-  const pkgUrl = url.resolve(regUrl, encodeURIComponent(pkgName).replace(/^%40/, '@'))
   const options =
     typeof opts === 'string'
       ? {range: opts, auth: true}
       : Object.assign({range: 'latest', auth: true}, opts)
 
+  const regUrl = resolveRegistryUrl(pkgName, options)
+  const pkgUrl = url.resolve(regUrl, encodeURIComponent(pkgName).replace(/^%40/, '@'))
   const authInfo = options.auth && registryAuthToken(regUrl, {recursive: true})
   const request = options.request || httpRequest
 

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,18 @@ test('can get specific version', () =>
 test('can opt-out of sending auth info', () =>
   expect(getLatestVersion('npm', {range: '^1.0.0', auth: false})).resolves.toBe('1.4.29'))
 
+test('can use custom registry', () => {
+  const inject = (evt) => {
+    expect(evt.context.options.url).toBe('https://custom-registry.npmjs.org/@some-scope%2Fsome-library')
+    return { body: { 'dist-tags': { latest: '1.0.0' }} }
+  }
+  const request = getLatestVersion.request.clone().use(injectResponse({inject}))
+  return getLatestVersion('@some-scope/some-library', {
+    request,
+    registryUrl: 'https://custom-registry.npmjs.org/'
+  })
+})
+
 test('rejects with package not found error', () =>
   getLatestVersion('##invalid##')
     .then(shouldNotResolve)


### PR DESCRIPTION
This pull request introduces new `registryUrl` option to manage registry manually instead of resolving it from NPM configuration.

Closes #11 

